### PR TITLE
Allow giving a reason when skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ The `utils.skip` function flags the task as "skipped".  The task must still retu
 values, and this function makes that easy:
 
 ```javascript
-return utils.skip({key: value})
+return utils.skip({provides: {key: value}})
+```
+
+You may optionally provide a reason for the skip:
+
+```javascript
+return utils.skip({provides: {key: value}, reason: 'skipped - already complete'})
 ```
 
 ### step
@@ -150,6 +156,7 @@ That renderer should have the following (sync!) methods:
  * `log` -- a line of log output from the task has arrived
  * `status` -- a status update, with the arguments to `util.status` as value
  * `step` -- a substep has begun; the value has `{title: ..}`
+ * `skip` -- a node has been skipped; the value is the reason (this occurs just after the state updates to `skipped`)
 
 ## States
 

--- a/example.js
+++ b/example.js
@@ -25,7 +25,7 @@ const delayTask = ({delay, skip, prog, message, ...task}) => {
       res[k] = true;
     }
     if (skip) {
-      return utils.skip(res);
+      return utils.skip(res, 'because..');
     } else {
       return res;
     }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "git@github.com:djmitche/console-taskgraph.git",
   "author": "Dustin J. Mitchell <dustin@mozilla.com>",
   "license": "MPL-2.0",
+  "files": [
+    "src/"
+  ],
   "scripts": {
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js",

--- a/src/taskgraph.js
+++ b/src/taskgraph.js
@@ -78,10 +78,11 @@ class TaskGraph {
       return value;
     };
 
-    utils.skip = provided => {
+    utils.skip = ({provides, reason}) => {
       node.state = 'skipped';
       this.renderer.update(node, 'state', 'skipped');
-      return provided;
+      this.renderer.update(node, 'skip', reason || 'skipped');
+      return provides;
     };
 
     utils.status = status => {
@@ -161,6 +162,8 @@ class ConsoleRenderer {
       }
       node.output.push(value.toString().trimRight());
       node.output = node.output.slice(-4);
+    } else if (change === 'skip') {
+      node.skipReason = value;
     } else if (change == 'status') {
       if (value.message) {
         node.message = value.message;
@@ -216,7 +219,7 @@ class ConsoleRenderer {
         }
 
       } else if (node.state === 'skipped') {
-        noderep.push(`${logSymbols.info} ${chalk.bold(node.task.title)} (skipped)`);
+        noderep.push(`${logSymbols.info} ${chalk.bold(node.task.title)} (${node.skipReason || 'skipped'})`);
       } else {
         noderep.push(`${logSymbols.success} ${chalk.bold(node.task.title)}`);
       }
@@ -250,6 +253,8 @@ class LogRenderer {
       output = `${node.task.title}: ${value}`;
     } else if (change === 'step') {
       output = `${node.task.title}: start step ${value.title}`;
+    } else if (change === 'skip') {
+      output = `${node.task.title}: skip - ${value}`;
     } else if (change === 'status') {
       if (value.message) {
         output = `${node.task.title}: ${value.message}`;

--- a/test/taskgraph_test.js
+++ b/test/taskgraph_test.js
@@ -75,7 +75,7 @@ suite('src/taskgraph.js', function() {
           requires: [],
           provides: ['a', 'b'],
           run: async (requirements, {skip}) => {
-            return skip({a: 10, b: 20});
+            return skip({provides: {a: 10, b: 20}});
           },
         }];
         const graph = new TaskGraph(nodes, {renderer});
@@ -85,6 +85,28 @@ suite('src/taskgraph.js', function() {
           'start',
           'state running SKIP',
           'state skipped SKIP',
+          'skip skipped SKIP',
+          'stop',
+        ]);
+      });
+
+      test('skips with a reason', async function() {
+        const renderer = new FakeRenderer();
+        const nodes = [{
+          title: 'SKIP',
+          requires: [],
+          provides: [],
+          run: async (requirements, {skip}) => {
+            return skip({reason: 'because'});
+          },
+        }];
+        const graph = new TaskGraph(nodes, {renderer});
+        const context = await graph.run();
+        assume(renderer.updates).to.deeply.equal([
+          'start',
+          'state running SKIP',
+          'state skipped SKIP',
+          'skip because SKIP',
           'stop',
         ]);
       });


### PR DESCRIPTION
We annotate a task title with `(skipped)` now, but it might be nice to allow a reason, e.g., `(skipped - already exists)`.