### PR TITLE
Mark a task with a red X when it throws an exception (and force a render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,4 @@ Nodes have the following states (with room to add more):
 * `running` -- currently executing
 * `skipped` -- completed, skipped
 * `finished` -- completed
+* `failed` -- failed with an exception

--- a/test/taskgraph_test.js
+++ b/test/taskgraph_test.js
@@ -99,6 +99,23 @@ suite('src/taskgraph.js', function() {
       ]);
     });
 
+    test('renders failures', async function() {
+      const renderer = new FakeRenderer();
+      const graph = new TaskGraph([{
+        title: 'FAIL',
+        run: async (requirements) => {
+          throw new Error('uhoh');
+        },
+      }], {renderer});
+      await assume(graph.run()).to.throwAsync();
+      assume(renderer.updates).to.deeply.equal([
+        'start',
+        'state running FAIL',
+        'state failed FAIL',
+        'stop',
+      ]);
+    });
+
     suite('utils.skip', function() {
       test('skips', async function() {
         const renderer = new FakeRenderer();


### PR DESCRIPTION
Even though we don't *handle* exceptions, we can tell when they happen, and this way when users get a stacktrace they can also see, above it, which task it occured in.