### PR TITLE
Finish other tasks on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ That renderer should have the following (sync!) methods:
  * `status` -- a status update, with the arguments to `util.status` as value
  * `step` -- a substep has begun; the value has `{title: ..}`
  * `skip` -- a node has been skipped; the value is the reason (this occurs just after the state updates to `skipped`)
+ * `fail` -- a node has failed; the value is the error object
 
 ## States
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ And configure tasks to require locks by including the lock name in the `locks` a
 
 The `new Lock(n)` constructs a lock that allows `n` tasks to use it simultaneously.
 
+# Error Handling
+
+Errors that occur in task execution are propagated out of the `run` method.
+
+However, any already-started tasks are allowed to finish before returning (this is
+the only choice, as a running Promise cannot be cancelled). Any further errors
+from those tasks are indicated in the rendered display, but will not be
+propagated.
+
 # Renderers
 
 Renderers are responsible for displaying the status of a graph execution as it

--- a/test/taskgraph_test.js
+++ b/test/taskgraph_test.js
@@ -112,6 +112,7 @@ suite('src/taskgraph.js', function() {
         'start',
         'state running FAIL',
         'state failed FAIL',
+        'fail Error: uhoh FAIL',
         'stop',
       ]);
     });

--- a/test/taskgraph_test.js
+++ b/test/taskgraph_test.js
@@ -3,9 +3,12 @@ const assume = require('assume');
 const {Readable} = require('stream');
 const Observable = require('zen-observable');
 
-const delayTask = ({delay, ...task}) => {
+const delayTask = ({delay, failWith, ...task}) => {
   task.run = async (requirements, provide) => {
     await new Promise(resolve => setTimeout(resolve, delay));
+    if (failWith) {
+      throw new Error(failWith);
+    }
     const res = {};
     for (const k of task.provides) {
       res[k] = true;
@@ -113,6 +116,37 @@ suite('src/taskgraph.js', function() {
         'state running FAIL',
         'state failed FAIL',
         'fail Error: uhoh FAIL',
+        'stop',
+      ]);
+    });
+
+    test('completes running tasks before throwing a failure', async function() {
+      const renderer = new FakeRenderer();
+      const graph = new TaskGraph([
+        delayTask({title: 'F1', failWith: 'uhoh 1', requires: [], provides: [], delay: 2}),
+        delayTask({title: 'F2', failWith: 'uhoh 2', requires: [], provides: [], delay: 3}),
+        delayTask({title: 'OK', requires: [], provides: [], delay: 4}),
+        delayTask({title: 'F3', failWith: 'uhoh 3', requires: [], provides: [], delay: 5}),
+      ], {renderer});
+      try {
+        await graph.run();
+        assert(false, 'expected an error');
+      } catch (err) {
+        assume(err).to.match(/uhoh 1/); // first error is thrown..
+      }
+      assume(renderer.updates).to.deeply.equal([
+        'start',
+        'state running F1',
+        'state running F2',
+        'state running OK',
+        'state running F3',
+        'state failed F1',
+        'fail Error: uhoh 1 F1',
+        'state failed F2',
+        'fail Error: uhoh 2 F2',
+        'state finished OK',
+        'state failed F3',
+        'fail Error: uhoh 3 F3',
         'stop',
       ]);
     });


### PR DESCRIPTION
When a task fails with an error, it's frustrating that all other tasks are abandoned immediately, rather than allowed to complete.  We should optionally support continuing all tasks until they complete, but not starting new tasks at that point.