### PR TITLE
Include the failing task in errors

### DIFF
--- a/src/taskgraph.js
+++ b/src/taskgraph.js
@@ -108,6 +108,9 @@ class TaskGraph {
             if (nodeCanStart(node)) {
               this._runNode(node, context).catch(err => {
                 if (!firstError) {
+                  // edit the message and stack to include a reference to the failing task
+                  err.message = err.message.replace(/(^.*)/, `$1 (while executing task ${node.task.title})`);
+                  err.stack = err.stack.replace(/(^.*)\n/, `$1 (while executing task ${node.task.title})`);
                   firstError = err;
                 }
               }).then(refresh);

--- a/test/taskgraph_test.js
+++ b/test/taskgraph_test.js
@@ -176,7 +176,8 @@ suite('src/taskgraph.js', function() {
         await graph.run();
         assert(false, 'expected an error');
       } catch (err) {
-        assume(err).to.match(/uhoh 1/); // first error is thrown..
+        // first error is thrown, with annotation of the failing task
+        assume(err.toString()).to.match(/Error: uhoh 1 \(while executing task F1\)/);
       }
       assume(renderer.updates).to.deeply.equal([
         'start',


### PR DESCRIPTION
This edits the error in place, so that it can retain other attributes
like `.code`, but includes the failing task in the message (and in the
stack in case it has already been derived from the message).

Fixes #15.